### PR TITLE
Update to support client rather than runtime object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,78 @@
 module github.com/wellplayedgames/tiny-operator
 
-go 1.14
+go 1.18
 
 require (
-	github.com/go-logr/logr v0.1.0
-	github.com/onsi/ginkgo v1.11.0
-	github.com/onsi/gomega v1.8.1
+	github.com/go-logr/logr v1.2.0
+	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/gomega v1.18.1
 	helm.sh/helm/v3 v3.2.4
-	k8s.io/api v0.18.2
-	k8s.io/apiextensions-apiserver v0.18.2
-	k8s.io/apimachinery v0.18.2
-	k8s.io/client-go v0.18.2
-	sigs.k8s.io/controller-runtime v0.6.0
+	k8s.io/api v0.24.0
+	k8s.io/apiextensions-apiserver v0.24.0
+	k8s.io/apimachinery v0.24.0
+	k8s.io/client-go v0.24.0
+	sigs.k8s.io/controller-runtime v0.12.0
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver/v3 v3.1.0 // indirect
+	github.com/Masterminds/sprig/v3 v3.1.0 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-logr/zapr v1.2.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/huandu/xstrings v1.3.1 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.19.1 // indirect
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.60.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
+	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/composite/composite_test.go
+++ b/pkg/composite/composite_test.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,8 +36,8 @@ var _ = Describe("Composite", func() {
 	Context("reconciling newly created resource", func() {
 		var parentResource unstructured.Unstructured
 		var parentKey types.NamespacedName
-		var sourceChildren []runtime.Object
-		var children []runtime.Object
+		var sourceChildren []client.Object
+		var children []client.Object
 
 		BeforeEach(func() {
 			parentResource = unstructured.Unstructured{}
@@ -54,7 +53,7 @@ var _ = Describe("Composite", func() {
 				Name:      parentResource.GetName(),
 			}
 
-			sourceChildren = []runtime.Object{
+			sourceChildren = []client.Object{
 				&corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "service-1",
@@ -63,9 +62,9 @@ var _ = Describe("Composite", func() {
 					Spec: corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{
 							{
-								Name: "http",
+								Name:     "http",
 								Protocol: corev1.ProtocolTCP,
-								Port: 80,
+								Port:     80,
 							},
 						},
 					},
@@ -78,18 +77,18 @@ var _ = Describe("Composite", func() {
 					Spec: corev1.ServiceSpec{
 						Ports: []corev1.ServicePort{
 							{
-								Name: "http",
+								Name:     "http",
 								Protocol: corev1.ProtocolTCP,
-								Port: 80,
+								Port:     80,
 							},
 						},
 					},
 				},
 			}
 
-			children = make([]runtime.Object, len(sourceChildren))
+			children = make([]client.Object, len(sourceChildren))
 			for idx, child := range sourceChildren {
-				children[idx] = child.DeepCopyObject()
+				children[idx] = child.DeepCopyObject().(client.Object)
 			}
 		})
 
@@ -163,7 +162,7 @@ var _ = Describe("Composite", func() {
 			}
 
 			for idx, child := range sourceChildren {
-				children[idx] = child.DeepCopyObject()
+				children[idx] = child.DeepCopyObject().(client.Object)
 			}
 
 			err := reconciler.Reconcile(ctx, children)
@@ -184,7 +183,7 @@ var _ = Describe("Composite", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			for idx, child := range sourceChildren {
-				children[idx] = child.DeepCopyObject()
+				children[idx] = child.DeepCopyObject().(client.Object)
 			}
 
 			err = reconciler.Reconcile(ctx, children)
@@ -225,7 +224,7 @@ var _ = Describe("Composite", func() {
 
 		By("reconciling initial children")
 
-		childrenA := []runtime.Object{
+		childrenA := []client.Object{
 			&corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-service",
@@ -234,9 +233,9 @@ var _ = Describe("Composite", func() {
 				Spec: corev1.ServiceSpec{
 					Ports: []corev1.ServicePort{
 						{
-							Name: "http",
+							Name:     "http",
 							Protocol: corev1.ProtocolTCP,
-							Port: 80,
+							Port:     80,
 						},
 					},
 				},
@@ -261,7 +260,7 @@ var _ = Describe("Composite", func() {
 		reconciler, err = composite.New(logger, k8sClient, scheme.Scheme, &parentResource, owner)
 		Expect(err).ToNot(HaveOccurred())
 
-		childrenB := []runtime.Object{
+		childrenB := []client.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-config-map",

--- a/pkg/composite/suite_test.go
+++ b/pkg/composite/suite_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = apiextensionsv1beta1.AddToScheme(scheme.Scheme)
+	err = apiextensionsv1.AddToScheme(scheme.Scheme)
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -60,24 +60,29 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(k8sClient).ToNot(BeNil())
 
 	// Create custom resource for our tests.
-	crd := apiextensionsv1beta1.CustomResourceDefinition{
+	crd := apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testresources.tiny-operator.wellplayed.games",
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: customResourceGVK.Group,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Kind:     customResourceGVK.Kind,
 				ListKind: "TestResources",
 				Plural:   "testresources",
 				Singular: "testresource",
 			},
-			Version: customResourceGVK.Version,
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
 					Name:    customResourceGVK.Version,
 					Served:  true,
 					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/composite/suite_test.go
+++ b/pkg/composite/suite_test.go
@@ -42,7 +42,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func(done Done) {
 	ctx := context.Background()
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{}
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	time.Sleep(250 * time.Millisecond)
 
-	Eventually(func() error { return k8sClient.Get(ctx, client.ObjectKey{ Name: crd.Name }, &crd) }).
+	Eventually(func() error { return k8sClient.Get(ctx, client.ObjectKey{Name: crd.Name}, &crd) }).
 		Should(Succeed())
 
 	close(done)

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -3,12 +3,11 @@ package patch
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // IsPatchRequired determines if a patch will produce a no-op
-func IsPatchRequired(newObj runtime.Object, patch client.Patch) (bool, error) {
+func IsPatchRequired(newObj client.Object, patch client.Patch) (bool, error) {
 	p, err := patch.Data(newObj)
 	if err != nil {
 		return false, err
@@ -18,7 +17,7 @@ func IsPatchRequired(newObj runtime.Object, patch client.Patch) (bool, error) {
 }
 
 // MaybePatch will patch an object if the patch does not produce a no-op
-func MaybePatch(ctx context.Context, client client.Client, newObj runtime.Object, patch client.Patch) (bool, error) {
+func MaybePatch(ctx context.Context, client client.Client, newObj client.Object, patch client.Patch) (bool, error) {
 	required, err := IsPatchRequired(newObj, patch)
 	if err != nil {
 		return false, fmt.Errorf("unable to build patch: %v", err)
@@ -32,7 +31,7 @@ func MaybePatch(ctx context.Context, client client.Client, newObj runtime.Object
 }
 
 // MaybePatchStatus will patch an object's status if the patch does not produce a no-op
-func MaybePatchStatus(ctx context.Context, client client.Client, newObj runtime.Object, patch client.Patch) (bool, error) {
+func MaybePatchStatus(ctx context.Context, client client.Client, newObj client.Object, patch client.Patch) (bool, error) {
 	required, err := IsPatchRequired(newObj, patch)
 	if err != nil {
 		return false, fmt.Errorf("unable to build patch: %v", err)

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -96,13 +96,11 @@ func (f fakeClient) Status() client.StatusWriter {
 }
 
 func (f fakeClient) Scheme() *runtime.Scheme {
-	//TODO implement me
-	panic("implement me")
+	panic("unimplemented")
 }
 
 func (f fakeClient) RESTMapper() meta.RESTMapper {
-	//TODO implement me
-	panic("implement me")
+	panic("unimplemented")
 }
 
 var _ client.Client = &fakeClient{}

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,7 +20,7 @@ func (b brokenPatcher) Type() types.PatchType {
 	return "broken"
 }
 
-func (b brokenPatcher) Data(obj runtime.Object) ([]byte, error) {
+func (b brokenPatcher) Data(obj client.Object) ([]byte, error) {
 	return nil, fmt.Errorf("why was I made to feel pain")
 }
 
@@ -52,46 +53,56 @@ func newFakeClient() fakeClient {
 	}
 }
 
-func (f fakeStatusWriter) Update(context.Context, runtime.Object, ...client.UpdateOption) error {
+func (f fakeStatusWriter) Update(context.Context, client.Object, ...client.UpdateOption) error {
 	panic("unimplemented")
 }
 
-func (f *fakeStatusWriter) Patch(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error {
+func (f *fakeStatusWriter) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
 	f.state.patchStatusCalled = true
 	return nil
 }
 
-func (f fakeClient) Get(context.Context, client.ObjectKey, runtime.Object) error {
+func (f fakeClient) Get(context.Context, client.ObjectKey, client.Object) error {
 	panic("unimplemented")
 }
 
-func (f fakeClient) List(context.Context, runtime.Object, ...client.ListOption) error {
+func (f fakeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	panic("unimplemented")
 }
 
-func (f fakeClient) Create(context.Context, runtime.Object, ...client.CreateOption) error {
+func (f fakeClient) Create(context.Context, client.Object, ...client.CreateOption) error {
 	panic("unimplemented")
 }
 
-func (f fakeClient) Delete(context.Context, runtime.Object, ...client.DeleteOption) error {
+func (f fakeClient) Delete(context.Context, client.Object, ...client.DeleteOption) error {
 	panic("unimplemented")
 }
 
-func (f fakeClient) Update(context.Context, runtime.Object, ...client.UpdateOption) error {
+func (f fakeClient) Update(context.Context, client.Object, ...client.UpdateOption) error {
 	panic("unimplemented")
 }
 
-func (f fakeClient) Patch(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error {
+func (f fakeClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
 	f.state.patchCalled = true
 	return nil
 }
 
-func (f fakeClient) DeleteAllOf(context.Context, runtime.Object, ...client.DeleteAllOfOption) error {
+func (f fakeClient) DeleteAllOf(context.Context, client.Object, ...client.DeleteAllOfOption) error {
 	panic("unimplemented")
 }
 
 func (f fakeClient) Status() client.StatusWriter {
 	return &f.statusWriter
+}
+
+func (f fakeClient) Scheme() *runtime.Scheme {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (f fakeClient) RESTMapper() meta.RESTMapper {
+	//TODO implement me
+	panic("implement me")
 }
 
 var _ client.Client = &fakeClient{}


### PR DESCRIPTION
This is needed for the other operators upgrades

#### TODO
- [x] Unfortunately on windows I cannot seem to run the tests (or in WSL), so would it be possible for someone to run them and check that they pass before I merge that in update the other operators